### PR TITLE
[PROJECT] Added Eclipse's required documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Community Code of Conduct
+
+**Version 2.0  
+January 1, 2023**
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as community members, contributors, Committers[^1], and Project Leads (collectively "Contributors") pledge to make participation in our projects and our community a harassment-free and inclusive experience for everyone.
+
+This Community Code of Conduct ("Code") outlines our behavior expectations as members of our community in all Eclipse Foundation activities, both offline and online. It is not intended to govern scenarios or behaviors outside of the scope of Eclipse Foundation activities. Nor is it intended to replace or supersede the protections offered to all our community members under the law. Please follow both the spirit and letter of this Code and encourage other Contributors to follow these principles into our work. Failure to read or acknowledge this Code does not excuse a Contributor from compliance with the Code.
+
+## Our Standards
+
+Examples of behavior that contribute to creating a positive and professional environment include:
+
+- Using welcoming and inclusive language;
+- Actively encouraging all voices;
+- Helping others bring their perspectives and listening actively. If you find yourself dominating a discussion, it is especially important to encourage other voices to join in;
+- Being respectful of differing viewpoints and experiences;
+- Gracefully accepting constructive criticism;
+- Focusing on what is best for the community;
+- Showing empathy towards other community members;
+- Being direct but professional; and
+- Leading by example by holding yourself and others accountable
+
+Examples of unacceptable behavior by Contributors include:
+
+- The use of sexualized language or imagery;
+- Unwelcome sexual attention or advances;
+- Trolling, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment, repeated harassment;
+- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Violent threats or language directed against another person;
+- Sexist, racist, or otherwise discriminatory jokes and language;
+- Posting sexually explicit or violent material;
+- Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history;
+- Personal insults, especially those using racist or sexist terms;
+- Excessive or unnecessary profanity;
+- Advocating for, or encouraging, any of the above behavior; and
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+With the support of the Eclipse Foundation employees, consultants, officers, and directors (collectively, the "Staff"), Committers, and Project Leads, the Eclipse Foundation Conduct Committee (the "Conduct Committee") is responsible for clarifying the standards of acceptable behavior. The Conduct Committee takes appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code applies within all Project, Working Group, and Interest Group spaces and communication channels of the Eclipse Foundation (collectively, "Eclipse spaces"), within any Eclipse-organized event or meeting, and in public spaces when an individual is representing an Eclipse Foundation Project, Working Group, Interest Group, or their communities. Examples of representing a Project or community include posting via an official social media account, personal accounts, or acting as an appointed representative at an online or offline event. Representation of Projects, Working Groups, and Interest Groups may be further defined and clarified by Committers, Project Leads, or the Staff.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via conduct@eclipse-foundation.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
+
+Staff, Committers and Project Leads have the right to report, remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code, or to block temporarily or permanently any Contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. Any such actions will be reported to the Conduct Committee for transparency and record keeping.
+
+Any Staff (including officers and directors of the Eclipse Foundation), Committers, Project Leads, or Conduct Committee members who are the subject of a complaint to the Conduct Committee will be recused from the process of resolving any such complaint.
+
+## Responsibility
+
+The responsibility for administering this Code rests with the Conduct Committee, with oversight by the Executive Director and the Board of Directors. For additional information on the Conduct Committee and its process, please write to <conduct@eclipse-foundation.org>.
+
+## Investigation of Potential Code Violations
+
+All conflict is not bad as a healthy debate may sometimes be necessary to push us to do our best. It is, however, unacceptable to be disrespectful or offensive, or violate this Code. If you see someone engaging in objectionable behavior violating this Code, we encourage you to address the behavior directly with those involved. If for some reason, you are unable to resolve the matter or feel uncomfortable doing so, or if the behavior is threatening or harassing, please report it following the procedure laid out below.
+
+Reports should be directed to <conduct@eclipse-foundation.org>. It is the Conduct Committee’s role to receive and address reported violations of this Code and to ensure a fair and speedy resolution.
+
+The Eclipse Foundation takes all reports of potential Code violations seriously and is committed to confidentiality and a full investigation of all allegations. The identity of the reporter will be omitted from the details of the report supplied to the accused. Contributors who are being investigated for a potential Code violation will have an opportunity to be heard prior to any final determination. Those found to have violated the Code can seek reconsideration of the violation and disciplinary action decisions. Every effort will be made to have all matters disposed of within 60 days of the receipt of the complaint.
+
+## Actions
+Contributors who do not follow this Code in good faith may face temporary or permanent repercussions as determined by the Conduct Committee.
+
+This Code does not address all conduct. It works in conjunction with our [Communication Channel Guidelines](https://www.eclipse.org/org/documents/communication-channel-guidelines/), [Social Media Guidelines](https://www.eclipse.org/org/documents/social_media_guidelines.php), [Bylaws](https://www.eclipse.org/org/documents/eclipse-foundation-be-bylaws-en.pdf), and [Internal Rules](https://www.eclipse.org/org/documents/ef-be-internal-rules.pdf) which set out additional protections for, and obligations of, all contributors. The Foundation has additional policies that provide further guidance on other matters.
+
+It’s impossible to spell out every possible scenario that might be deemed a violation of this Code. Instead, we rely on one another’s good judgment to uphold a high standard of integrity within all Eclipse Spaces. Sometimes, identifying the right thing to do isn’t an easy call. In such a scenario, raise the issue as early as possible.
+
+## No Retaliation
+
+The Eclipse community relies upon and values the help of Contributors who identify potential problems that may need to be addressed within an Eclipse Space. Any retaliation against a Contributor who raises an issue honestly is a violation of this Code. That a Contributor has raised a concern honestly or participated in an investigation, cannot be the basis for any adverse action, including threats, harassment, or discrimination. If you work with someone who has raised a concern or provided information in an investigation, you should continue to treat the person with courtesy and respect. If you believe someone has retaliated against you, report the matter as described by this Code. Honest reporting does not mean that you have to be right when you raise a concern; you just have to believe that the information you are providing is accurate.
+
+False reporting, especially when intended to retaliate or exclude, is itself a violation of this Code and will not be accepted or tolerated.
+
+Everyone is encouraged to ask questions about this Code. Your feedback is welcome, and you will get a response within three business days. Write to <conduct@eclipse-foundation.org>.
+
+## Amendments
+
+The Eclipse Foundation Board of Directors may amend this Code from time to time and may vary the procedures it sets out where appropriate in a particular case.
+
+### Attribution
+
+This Code was inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
+
+[^1]: Capitalized terms used herein without definition shall have the meanings assigned to them in the Bylaws.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+# Contributing to TMLL
+
+Thanks for your interest in this project. This page explains how to contribute code to the Trace Compass TMLL project.
+
+## Terms of Use
+
+This repository is subject to the [Terms of Use of the Eclipse Foundation][terms].
+
+## Code of Conduct
+
+This project is governed by the [Eclipse Community Code of Conduct][code-of-conduct].
+By participating, you are expected to uphold this code.
+
+## Eclipse Development Process
+
+This Eclipse Foundation open project is governed by the [Eclipse Foundation
+Development Process][dev-process] and operates under the terms of the [Eclipse IP Policy][ip-policy].
+
+## Eclipse Contributor Agreement
+
+In order to be able to contribute to Eclipse Foundation projects you must
+electronically sign the [Eclipse Contributor Agreement (ECA)][eca].
+
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
+
+For more information, please see the [Eclipse Committer Handbook][commiter-handbook].
+
+## Setting up the development environment
+
+To set up the environment for running TMLL, you need to install Python 3.8 or higher on your machine. TMLL uses [tsp-python-client][tsp-python-client] as a submodule to communicate with the trace server. Therefore, you must first clone its repository as a submodule:  
+
+```bash
+git submodule update --init
+```
+
+After fetching the submodule, you need to configure its path in your entry Python file to ensure proper path handling:  
+
+```python
+import sys
+sys.path.append("tmll/tsp")
+```
+
+At this stage, you may create a virtual environment to manage TMLL's dependencies properly without affecting your globally installed packages.
+
+```bash
+python3 -m venv venv
+source venv/bin/activate # If Linux or MacOS
+.\venv\Scripts\activate # If Windows 
+
+# Install the required dependencies
+pip3 install -r requirements.txt
+```
+
+## Running TMLL
+In order to understand how TMLL should be initialized, please refer to its [documentation][tmll-documentation].
+
+## Source code tree
+This source tree contains the source code of TMLL.
+
+```bash
+tmll
+  ├── common/ # common resources across the framework
+  │   ├── models/ # trace, experiment, outputs, trees, etc.
+  │   └── services/ # logger, etc.
+  ├── ml/
+  │   ├── modules/ # anomaly detection, root cause analysis, resource optimization, etc.
+  │   ├── preprocess/ # normalization, feature manipulation, encoding/decoding, etc.
+  │   ├── utils/ # documentor, formatter, etc.
+  │   └── visualization/ # everything related to plots
+  ├── services/ # external services, such as instrumentation or trace-server installer
+  ├── tsp/ # tsp-python-client submodule
+  └── utils/ # infra-related utils
+
+```
+    
+## When to submit patches
+
+Remember that contributions are always welcome!
+
+If you have a simple and straightforward fix to an obvious bug, feel free to push
+it directly to the project's GitHub (see below).
+
+This project uses GitHub issues to track ongoing development and issues. In order
+to contribute, please first [open an issue][issues] that clearly describes the
+bug you intend to fix or the feature you would like to add. Make sure you provide
+a way to reproduce the bug or test the proposed feature.
+
+If you wish to work on a larger problem or feature, it would be a good idea to 
+[contact us](#contact) first. It could avoid duplicate work in case somebody is
+already working on the same thing. For substantial new features, it is always good
+to discuss their design and integration first.
+
+Be sure to search for existing bugs before you create another one. 
+
+## Where to submit
+
+TMLL uses GitHub pull requests for submitting patches and review contributions
+
+Once you have your code ready for review, please  [open a pull request][pull-requests]. Please follow
+the [pull request guidelines][pr-guide]. If you are new to the project, the
+[new contributors][new-contributors] section provides useful information to get you started. A
+committer of TMLL will then review your contribution and help to get it merged.
+
+### The review process
+
+We will try to give feedback to new patches in a reasonable amount of time, usually in the following days. Smaller patches makes the review go faster.
+
+With the exception of “trivial patches”, as in, patches that either don’t change the compiled code (e.g., comments, commit messages), we try to have two (2) committers review every patch that goes in. For a patch from a committer, this means a second committer should review it, even for the trivial ones. For a patch from a non-committer, one committer should do a thorough review, and at least a second one should give a quick look.
+
+A committer may update the patch being submitted, then the original author must review it. This is useful if the author has minor nits to fix, e.g., spaces.
+
+For a patch to be approved, it needs to be marked as `Approved` and all automatic checks need to be successful. Code Review means the patch "looks" good, it follows the coding style, uses relevant algorithms and data structures, etc. Verified in general means that the patch technically works, it compiles, the tests pass, and it does what it is supposed to do.
+
+A reviewer may request changes if pull request needs updates or if verfication reasons.
+
+The meanings of each score are listed below. 
+
+## Code Review
+
+`Approved:` The reviewer considers that the patch follows the coding style, and implements the expected functionality correctly. Reviewers are strongly encouraged to run and verify the contribution of the pull requests, except very trivial ones. At least one `Approved` is required for the patch to go in. Only committers can give this score.
+
+`Commented:` The reviewer considers that this patch is good, but that someone else should also take a look at parts or the totality of the patch. Should be accompanied with a comment indicating what is missing to approve it if the review is from a committer. Anybody with write access can give this score.
+
+`Changes Requested:` There are some things that should be fixed first. Should always be accompanied with general and/or inline comments indicating areas of the code that need improvement. All comments that are given are expected to be either A) fixed in a subsequent patchset or B) replied to with explanation/justification. If the overall direction of the patch is not the right one and it warrants further discussion, the reviewer needs to state that in the pull request. Meaning discussions on the pull request, GitHub issues, the mailing list, or in person. 
+
+## Pull request guidelines
+
+**Changes to the project** are made by submitting code with a pull request (PR).
+
+* [How to write and submit changes][creating-changes]
+
+**Good commit messages** make it easier to review code and understand why the changes were made.
+Please include a:
+
+* `Title:` Concise and complete title written in imperative (e.g. "Update Gitpod demo screenshots"
+or "Single-click to select or open trace")
+* `Problem:` What is the situation that needs to be resolved? Why does the problem need fixing?
+Link to related issues (e.g. "Fixes #317").
+* `Solution:` What changes were made to resolve the situation? Why are these changes the right fix?
+* `Impact:` What impact do these changes have? (e.g. Numbers to show a performance improvement,
+screenshots or a video for a UI change)
+* [*Sign-off:*][sign-off] Use your full name and a long-term email address. This certifies that you
+have written the code and that, from a licensing perspective, the code is appropriate for use in open-source.
+
+Other commit information:
+
+* [How to format the message][commit-message-message]
+* Your patch should not introduce any error or warning.
+* Follow the project's [coding style][code-style]. It is defined in Eclipse project settings, which are committed in the tree, so simply hitting Ctrl+Shift+F in Eclipse should auto-format the current file.
+  * Basically, 4 spaces for indentation.
+  * We've turned off the auto-wrapping and unwrapping of lines, because it was doing more harm than good. Please wrap lines to reasonable lengths (100-120 is a good soft limit). Do NOT wrap after '.' (method invocations), it makes the code less readable. After '(' or ',' is usually good.
+* Split your larger contributions in smaller, independent pull requests 'that could go in independently of each other'. It is not unusual to have patch #1 go in quickly, but then have patch #2 go through many rounds of review. Smaller commits make the process faster for everyone (remember, the time taken to review a patch is ''n^2'', where ''n'' is the number of lines in the patch!)
+* If the patch is significant enough to have a mention in the New & Noteworthy, annotate the patch with `[Fixed]`, `[Added]`, `[Changed]`, `[Deprecated]`, or `[Security]` with a short description of what the change does.
+
+# API policy
+TMLL is currently in the incubation phase. A comprehensive API policy will be introduced in the repository upon reaching version 1.0.
+
+## Contact
+
+Contact the project developers via the [project's "dev" mailing list][mailing-list] or open an [issue tracker][issues].
+
+[code-of-conduct]: https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md
+[code-style]: https://wiki.eclipse.org/Trace_Compass/Contributor_Guidelines
+[commit-message-message]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[commiter-handbook]: https://www.eclipse.org/projects/handbook/#resources-commit
+[creating-changes]: https://www.dataschool.io/how-to-contribute-on-github/
+[dev-process]: https://eclipse.org/projects/dev_process
+[eca]: http://www.eclipse.org/legal/ECA.php
+[ip-policy]: https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+[issues]: https://github.com/eclipse-tracecompass/tmll/issues
+[mailing-list]: https://dev.eclipse.org/mailman/listinfo/tracecompass-dev
+[pr-guide]: #pull-request-guidelines
+[pull-requests]: https://github.com/eclipse-tracecompass/tmll/pulls
+[sign-off]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff
+[terms]: https://www.eclipse.org/legal/termsofuse.php
+[tsp-python-client]: https://github.com/eclipse-cdt-cloud/tsp-python-client
+[tmll-documentation]: https://tmll.gitbook.io/docs

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,40 @@
+# Notices for Eclipse Trace Compass TMLL
+
+This content is produced and maintained by the Eclipse Trace Compass project.
+
+* Project home:
+   https://github.com/eclipse-tracecompass
+
+## Trademarks
+
+Eclipse Trace Compass, and Trace Compass are trademarks of the Eclipse
+Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the MIT License which is available at
+https://opensource.org/licenses/MIT.
+
+SPDX-License-Identifier: MIT
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-tracecompass/tmll
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.

--- a/SECURITY
+++ b/SECURITY
@@ -1,0 +1,10 @@
+# Security Policy
+
+This project implements the Eclipse Foundation Security Policy
+
+* https://www.eclipse.org/security
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities to the Eclipse Foundation Security Team at
+security@eclipse.org

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,14 @@ To find out more on TMLL modules along with their usage instructions, check out 
 - API Reference: TBD
 - Tutorials: TBD
 
+## Contributing
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details on how to:
+
+- Submit bug reports and feature requests
+- Set up your development environment
+- Submit pull requests
+- Follow our coding standards
+
 ## Support
 
 - Create an [issue](https://github.com/eclipse-tracecompass/tmll/issues) for bug reports or feature requests


### PR DESCRIPTION
The required proposed documents by Eclipse Foundation have been added to the repository. The documents are as follows:
1. Code of Conduct
2. Contribution (i.e., guide)
3. Notice
4. Security

[Added] Multiple documents that Eclipse Foundation requires