### PR TITLE
Fix error of unterminated string literal

### DIFF
--- a/tmll/ml/modules/resource_optimization/idle_resource_detection_module.py
+++ b/tmll/ml/modules/resource_optimization/idle_resource_detection_module.py
@@ -433,8 +433,7 @@ class IdleResourceDetection(BaseModule):
                     total_duration = 0
 
             overall_metrics[f"{resource_type.name} Average Usage"] = usage_str
-            overall_metrics[f"{resource_type.name} Monitoring Duration"] = f"{
-                total_duration:.2f}s" if total_duration > 0 else "N/A (No data available)"
+            overall_metrics[f"{resource_type.name} Monitoring Duration"] = f"{total_duration:.2f}s" if total_duration > 0 else "N/A (No data available)"
 
         DocumentGenerator.metrics_group("Overall Resources Utilization", overall_metrics)
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/tmll/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Fixes the following error:

```
File: idle_resource_detection_module.py:436
    overall_metrics[f\"{resource_type.name} Monitoring Duration\"] =
f\"{
                                                                   ^
SyntaxError: unterminated string literal (detected at line 436)
```

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Run AnomalyDetection as per https://tmll.gitbook.io/docs

### Follow-ups
N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
