### PR TITLE
Fix f-string error in capacity_planning_module.py

### DIFF
--- a/tmll/ml/modules/predictive_maintenance/capacity_planning_module.py
+++ b/tmll/ml/modules/predictive_maintenance/capacity_planning_module.py
@@ -529,7 +529,7 @@ class CapacityPlanning(BaseModule):
                 if metrics.threshold_violations:
                     next_violation = metrics.threshold_violations[0]
                     resource_metrics["Next Threshold Violation"] = (
-                        f"{next_violation[0].strftime("%Y-%m-%d %H:%M:%S.%f")} "
+                        f"{next_violation[0].strftime('%Y-%m-%d %H:%M:%S.%f')} "
                     )
                     resource_metrics["Total Violations"] = str(len(metrics.threshold_violations))
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/tmll/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Replace quotes with single quotes to fix:

```
    from .capacity_planning_module import CapacityPlanning
E     File "./tmll/ml/modules/predictive_maintenance/capacity_planning_module.py",
line 532
E       f"{next_violation[0].strftime("%Y-%m-%d %H:%M:%S.%f")} "
E                                      ^
E   SyntaxError: f-string: unmatched '('
```
<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Run successfully CapacityPlanning analysis.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups
N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
