### PR TITLE
[UPDATE] Support data fetching density from trace server

### DIFF
--- a/tmll/ml/modules/base_module.py
+++ b/tmll/ml/modules/base_module.py
@@ -41,12 +41,12 @@ class BaseModule(ABC):
         Plot the given plots. 
 
         :param plots: The plots to plot. Each plot should be a dictionary with the following keys:
-            - plot_type (PLOT_TYPES): The type of the plot (e.g., 'time_series' or 'scatter')
+            - plot_type (PLOT_TYPES): The type of the plot (e.g., "time_series" or "scatter")
             - data (Any): The data to plot
             - x (str): The name of the x-axis column
             - y (str): The name of the y-axis column
             - hue (str, optional): The name of the hue column. Default is None
-            - color (str, optional): The color of the plot. Default is 'blue'
+            - color (str, optional): The color of the plot. Default is "blue"
         :type plots: List[Dict[str, Any]]
         :param plot_size: The size of the plot. Default is (15, 10)
         :type plot_size: Tuple[int, int], optional
@@ -62,31 +62,31 @@ class BaseModule(ABC):
         :return: None
         """
         # Create a new figure and axis
-        fig, ax = plt.subplots(figsize=plot_size, dpi=kwargs.get('dpi', 100))
+        fig, ax = plt.subplots(figsize=plot_size, dpi=kwargs.get("dpi", 100))
 
         # Plot each plot
         for plot_info in plots:
-            plot_type = plot_info.get('plot_type', None)
-            data = plot_info.get('data', None)
+            plot_type = plot_info.get("plot_type", None)
+            data = plot_info.get("data", None)
 
             # Create the plot
             plot_strategy = PlotFactory.create_plot(plot_type)
-            plot_strategy.plot(ax, data, **{k: v for k, v in plot_info.items() if k not in ['plot_type', 'data']})
+            plot_strategy.plot(ax, data, **{k: v for k, v in plot_info.items() if k not in ["plot_type", "data"]})
 
         # Set the title, x-axis label, and y-axis label of the plot
-        ax.set_title(kwargs.get('fig_title', ''))
-        ax.set_xlabel(kwargs.get('fig_xlabel', ''))
-        ax.set_ylabel(kwargs.get('fig_ylabel', ''))
+        ax.set_title(kwargs.get("fig_title", ""))
+        ax.set_xlabel(kwargs.get("fig_xlabel", ""))
+        ax.set_ylabel(kwargs.get("fig_ylabel", ""))
 
-        if kwargs.get('fig_xticks', None) is not None:
-            ax.set_xticks(kwargs.get('fig_xticks'))  # type: ignore
+        if kwargs.get("fig_xticks", None) is not None:
+            ax.set_xticks(kwargs.get("fig_xticks"))  # type: ignore
 
-        if kwargs.get('fig_yticks', None) is not None:
-            ax.set_yticks(kwargs.get('fig_yticks'))  # type: ignore
+        if kwargs.get("fig_yticks", None) is not None:
+            ax.set_yticks(kwargs.get("fig_yticks"))  # type: ignore
         else:
             y_min, y_max = ax.get_ylim()
             if isinstance(y_min, (int, float)) and isinstance(y_max, (int, float)):
-                num_yticks = kwargs.get('fig_num_yticks', 6)
+                num_yticks = kwargs.get("fig_num_yticks", 6)
                 yticks = PlotUtils.get_formatted_ticks(y_min, y_max, num_yticks)
                 ax.set_yticks(yticks)
 
@@ -95,27 +95,27 @@ class BaseModule(ABC):
                 ax.set_ylim(yticks[0] - padding, yticks[-1] + padding)
                 ax.set_yticklabels([f"{val:.2f}{unit}" for tick in yticks for val, unit in [Formatter.format_large_number(tick)]])
 
-        if kwargs.get('fig_xticklabels', None) is not None:
-            ax.set_xticklabels(kwargs.get('fig_xticklabels'))  # type: ignore
-        if kwargs.get('fig_yticklabels', None) is not None:
-            ax.set_yticklabels(kwargs.get('fig_yticklabels'))  # type: ignore
-        if kwargs.get('fig_xticklabels_rotation', None) is not None:
+        if kwargs.get("fig_xticklabels", None) is not None:
+            ax.set_xticklabels(kwargs.get("fig_xticklabels"))  # type: ignore
+        if kwargs.get("fig_yticklabels", None) is not None:
+            ax.set_yticklabels(kwargs.get("fig_yticklabels"))  # type: ignore
+        if kwargs.get("fig_xticklabels_rotation", None) is not None:
             ax.set_xticks(ax.get_xticks())
-            ax.set_xticklabels(ax.get_xticklabels(), rotation=kwargs.get('fig_xticklabels_rotation'))
-        if kwargs.get('fig_yticklabels_rotation', None) is not None:
+            ax.set_xticklabels(ax.get_xticklabels(), rotation=kwargs.get("fig_xticklabels_rotation"))
+        if kwargs.get("fig_yticklabels_rotation", None) is not None:
             ax.set_yticks(ax.get_yticks())
-            ax.set_yticklabels(ax.get_yticklabels(), rotation=kwargs.get('fig_yticklabels_rotation'))
+            ax.set_yticklabels(ax.get_yticklabels(), rotation=kwargs.get("fig_yticklabels_rotation"))
 
         # Add the legend to the plot (remove duplicates)
-        if kwargs.get('legend', True):
+        if kwargs.get("legend", True):
             handles, labels = plt.gca().get_legend_handles_labels()
             by_label = dict(zip(labels, handles))
-            PlotUtils.set_standard_legend_style(ax, by_label.values(), by_label.keys(), title=kwargs.get('legend_title', None))
+            PlotUtils.set_standard_legend_style(ax, by_label.values(), by_label.keys(), title=kwargs.get("legend_title", None))
         else:
             if ax.get_legend():
                 ax.get_legend().remove()
 
-        ax.grid(kwargs.get('grid', True))
+        ax.grid(kwargs.get("grid", True))
 
         # Display the plot
         plt.tight_layout()
@@ -134,7 +134,8 @@ class BaseModule(ABC):
         data, outputs = self.data_fetcher.fetch_data(
             experiment=self.experiment,
             target_outputs=outputs,
-            **kwargs.get('fetch_params', {}))
+            resample_freq=kwargs.get("resample_freq", "1s"),
+            **kwargs.get("fetch_params", {}))
 
         if data is None:
             self.logger.error("No data fetched")
@@ -153,26 +154,26 @@ class BaseModule(ABC):
 
                 if converted and converted.type == "TIME_GRAPH":
                     df = df.rename({"start_time": "timestamp"}, axis=1)
-                    df['end_time'] = pd.to_datetime(df['end_time'])
+                    df["end_time"] = pd.to_datetime(df["end_time"])
 
                 # Apply common preprocessing steps
-                if kwargs.get('normalize', True):
+                if kwargs.get("normalize", True):
                     df = self.data_preprocessor.normalize(df)
-                if kwargs.get('convert_datetime', True):
+                if kwargs.get("convert_datetime", True):
                     df = self.data_preprocessor.convert_to_datetime(df)
-                if kwargs.get('resample', True):
-                    df = self.data_preprocessor.resample(df, frequency=kwargs.get('resample_freq', '1s'))
-                if kwargs.get('remove_minimum', False):
+                if kwargs.get("resample", True):
+                    df = self.data_preprocessor.resample(df, frequency=kwargs.get("resample_freq", "1s"))
+                if kwargs.get("remove_minimum", False):
                     df = self.data_preprocessor.remove_minimum(df)
 
                 self.dataframes[shortened] = df
 
         # Filter out dataframes with less than min_size instances
-        min_size = kwargs.get('min_size', 1)
+        min_size = kwargs.get("min_size", 1)
         self.dataframes = {k: v for k, v in self.dataframes.items() if len(v) >= min_size}
 
         # Align timestamps if needed
-        if kwargs.get('align_timestamps', True) and self.dataframes:
+        if kwargs.get("align_timestamps", True) and self.dataframes:
             self.dataframes, self.timestamps = DataPreprocessor.align_timestamps(self.dataframes)
 
         # Call module-specific post-processing


### PR DESCRIPTION
### What it does

Previously, TMLL was used to retrieve data (XY and TIMEGRAPH) from the trace server with the parameters of the experiment's start to end and 65536 items in that specific time range. Now, based on the indicated resampling frequency (e.g., 1s, 5ms, 100us, etc.), the client can indicate how many data points it's required to be fetched from the server.

### How to test

When fetching specific data providers (e.g., CPU Usage), you can verify the number of fetched data points based on the given resampling frequency. For instance, if you tend to use the *Anomaly Detection* module, you may initialize it as below:
```python
from tmll.ml.modules.anomaly_detection.anomaly_detection_module import AnomalyDetection

# client = ...
# experiment = ...
# outputs = ...

# Here, if you change the resample_freq parameter, the amount of fetched data will be changed. So, a higher
# value will result in a lower number of data points, and vice versa.
ad = AnomalyDetection(client, experiment, outputs, resample_freq="1ms")

# ...rest of the code
```

So, for a sample trace, if you set the resampling frequency to **5ms**, the data of CPU Usage would be something like:
![image](https://github.com/user-attachments/assets/d66be60f-6acd-4a1f-be6a-f5a2401ace2b)
But, if you reduce this frequency to something like 100us, then it would be:
![image](https://github.com/user-attachments/assets/2d892d6c-a974-45d8-9425-53ac8d93e44d)


### Follow-ups

Performance evaluations should be assessed. Higher data fetching density may result in excessive processing time, which might not be realistic/feasible in real-time and resource-constraint environments.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
