### PR TITLE
Update CLI command names and syntax in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,31 +152,31 @@ TMLL includes a command-line interface for running analyses without writing code
 
 ```bash
 # Create an experiment
-tmll_cli.py create --traces /path/to/trace1 /path/to/trace2 --name "My Experiment"
+python3 -m tmll.mcp.cli create /path/to/trace1 /path/to/trace2 --name "My Experiment"
 
 # List outputs for an experiment
-tmll_cli.py list-outputs --experiment <UUID>
+python3 -m tmll.mcp.cli list-outputs <UUID>
 
 # Fetch data from outputs
-tmll_cli.py fetch-data --experiment <UUID> --keywords "cpu usage"
+python3 -m tmll.mcp.cli fetch-data <UUID> --keywords "cpu usage"
 
 # Run anomaly detection
-tmll_cli.py detect-anomalies --experiment <UUID> --keywords "cpu usage" --method iforest
+python3 -m tmll.mcp.cli anomaly <UUID> --keywords "cpu usage" --method iforest
 
 # Detect memory leaks
-tmll_cli.py detect-memory-leak --experiment <UUID>
+python3 -m tmll.mcp.cli memory-leak <UUID>
 
 # Detect change points
-tmll_cli.py detect-changepoints --experiment <UUID> --method pelt
+python3 -m tmll.mcp.cli changepoint <UUID> --methods single
 
 # Analyze correlations
-tmll_cli.py analyze-correlation --experiment <UUID> --method pearson
+python3 -m tmll.mcp.cli correlation <UUID> --method pearson
 
 # Detect idle resources
-tmll_cli.py detect-idle --experiment <UUID> --threshold 5
+python3 -m tmll.mcp.cli idle-resources <UUID> --cpu-idle-threshold 5
 
 # Run capacity planning
-tmll_cli.py plan-capacity --experiment <UUID> --horizon 30
+python3 -m tmll.mcp.cli capacity <UUID> --horizon 30
 ```
 
 ### Options
@@ -184,6 +184,7 @@ tmll_cli.py plan-capacity --experiment <UUID> --horizon 30
 - `--host`: Trace Server host (default: localhost)
 - `--port`: Trace Server port (default: 8080)
 - `--verbose`: Enable verbose output
+- `--log-stderr`: Send logs to stderr instead of stdout
 
 ## Prerequisites
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/tmll/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Fixes outdated CLI command names and usage examples in the README's "CLI Usage" section.

The documented commands no longer match the actual CLI (`tmll/mcp/cli.py`):
- `tmll_cli.py` does not exist as a standalone script, the CLI is invoked via `python3 -m tmll.mcp.cli`
- Command names have changed (e.g. `detect-anomalies` to `anomaly`)
- `--experiment <UUID>` is a positional argument, not a flag
- `--method` does not exist on `changepoint`, it is `--methods` (plural)
- `--threshold` does not exist on `idle-resources`, it is `--cpu-idle-threshold` / `--memory-idle-threshold` / `--disk-idle-threshold`
- Added the missing `--log-stderr` option to the "Options" section

### How to test

1. Install TMLL from source and start a local Trace Server
2. Run any of the corrected commands shown in the updated README.
3. Each corrected command was run on  a local Trace Compass server (port 8080) using the `network-experiment/serverKernel` sample trace from the [Tracevizlab tutorials](https://github.com/dorsal-lab/Tracevizlab/blob/master/labs/TraceCompassTutorialTraces.tgz), confirming it runs without `command not found` or `unrecognized arguments` errors

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
